### PR TITLE
Fix for compacting GC in Ruby 2.7

### DIFF
--- a/ext/afl_ext/afl_ext.c
+++ b/ext/afl_ext/afl_ext.c
@@ -199,6 +199,7 @@ static VALUE afl_bail_bang(VALUE _self) {
 
 void Init_afl_ext(void) {
     AFL = rb_const_get(rb_cObject, rb_intern("AFL"));
+    rb_gc_register_mark_object(AFL);
     LOG("...\n");
 
     rb_define_module_function(AFL, "trace", afl_trace, 2);


### PR DESCRIPTION
Ruby's compacting GC algorithm in 2.7 requires marking C globals when retaining references to them.

Learn more in this talk:
https://www.youtube.com/watch?v=1F3gXYhQsAY&t=2313s